### PR TITLE
Add placeholder .bazelrc for remote execution

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+#build --remote_executor=grpc://localhost:8980


### PR DESCRIPTION
This file is required for remote execution tests